### PR TITLE
fix: send as json instead

### DIFF
--- a/nodes/gotify-notification.js
+++ b/nodes/gotify-notification.js
@@ -41,7 +41,7 @@ module.exports = function(RED) {
         formData.extras = extras
       }
     
-      request.post(this.server.endpointUrl, { formData }, (error, response, body) => {
+      request.post(this.server.endpointUrl, { json: formData }, (error, response, body) => {
         if (!error && response.statusCode == 200) {
           this.status({
             fill: "green",


### PR DESCRIPTION
Sending as json data instead of html form data. This allows us to make use of `extras` for gotify messages.